### PR TITLE
add retry policy

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hden/duct.database.datomic "0.2.0"
+(defproject hden/duct.database.datomic "0.3.0"
   :description "Integrant methods for connecting to a Datomic Cloud database"
   :url "https://github.com/hden/duct.database.datomic"
   :license {:name "EPL-2.0"
@@ -6,6 +6,7 @@
   :repositories [["datomic-cloud" {:url "s3://datomic-releases-1fc2183a/maven/releases"}]]
   :managed-dependencies [[com.datomic/client-cloud "1.0.120"]]
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [integrant "0.8.0"]
-                 [com.datomic/client-cloud]]
+                 [com.datomic/client-cloud]
+                 [diehard "0.11.3"]
+                 [integrant "0.8.0"]]
   :repl-options {:init-ns duct.database.datomic})

--- a/src/duct/database/datomic.clj
+++ b/src/duct/database/datomic.clj
@@ -1,22 +1,44 @@
 (ns duct.database.datomic
-  (:require [integrant.core :as ig]
+  (:require [cognitect.anomalies :as anomalies]
             [datomic.client.api :as datomic]
-            [datomic.client.api.protocols :as client-protocols]))
+            [datomic.client.api.protocols :as client-protocols]
+            [diehard.core :as diehard]
+            [integrant.core :as ig]))
+
+(def retryable-anomaly?
+  "Set of retryable anomalies."
+  #{::anomalies/busy
+    ::anomalies/unavailable
+    ::anomalies/interrupted})
+
+(defn- retry? [_ e]
+  (-> e ex-data ::anomalies/category retryable-anomaly?))
+
+(def default-retry-policy
+  {:backoff-ms    [10 1000]
+   :jitter-factor 0.25
+   :max-retries   5
+   :retry-if      retry?})
 
 (defrecord Boundary [client connection])
 
 (defn- connect-ensure-database
   "Ensure that a database named db-name exists. Returns a connection."
-  [client db-name]
+  [{:keys [client db-name retry-policy]}]
   {:pre [(and (satisfies? client-protocols/Client client)
               (string? db-name))]}
   (when-not (contains? (into #{} (datomic/list-databases client {}))
                        db-name)
     (datomic/create-database client {:db-name db-name}))
-  (datomic/connect client {:db-name db-name}))
+  (diehard/with-retry retry-policy
+    (datomic/connect client {:db-name db-name})))
 
 (defmethod ig/init-key :duct.database/datomic
-  [_ {:keys [database] :as options}]
+  [_ {:keys [database retry-policy]
+      :or {retry-policy default-retry-policy}
+      :as options}]
   (let [client (datomic/client (dissoc options :database))
-        connection (when database (connect-ensure-database client database))]
+        connection (when database (connect-ensure-database {:client client
+                                                            :database database
+                                                            :retry-policy retry-policy}))]
     (->Boundary client connection)))


### PR DESCRIPTION
Datomic client might not be able to connect to a database when it is not ready (a rare condition).
This PR adds a retry condition to handle this edge case.